### PR TITLE
small compile dependency change to build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ repositories {
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web:0.5.0.M2")
+    compile("org.thymeleaf:thymeleaf-spring3:2.0.17")
     testCompile("junit:junit:4.11")
 }
 


### PR DESCRIPTION
I work for Pivotal. This is a fix for build.gradle on the docs page (README.md) to include the thymeleaf plugin dependancy. 
