### PR TITLE
fix jar naming when building with gradle

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
 
-jar {
+bootJar {
     baseName = 'gs-serving-web-content'
     version =  '0.1.0'
 }

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
 
-jar {
+bootJar {
     baseName = 'gs-serving-web-content'
     version =  '0.1.0'
 }


### PR DESCRIPTION
Hello,

When building the project with gradle, the generated jar is:

    build/libs/initial.jar

instead of

    build/libs/gs-serving-web-content-0.1.0.jar

Fixing the goal name (`jar` -> `bootJar`) fixes the problem.

Should we fix the test, too? It is not easy to do for initial/ , but we could try to build complete/ and check the name of the jar file.

Kind regards,

Bernard