### PR TITLE
fix tiny typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -119,7 +119,7 @@ This change demonstrates that the {RequestParam}[`@RequestParam`] arrangement in
 
 == Add a Home Page
 
-Static resources, like HTML or JavaScript or CSS, can easily be served from your Spring Boot application just be dropping them into the right place in the source code. By default Spring Boot serves static content from resources in the classpath at "/static" (or "/public"). The `index.html` resource is special because it is used as a "welcome page" if it exists, which means it will be served up as the root resource, i.e. at `http://localhost:8080/` in our example. So create this file:
+Static resources, like HTML or JavaScript or CSS, can easily be served from your Spring Boot application just by dropping them into the right place in the source code. By default Spring Boot serves static content from resources in the classpath at "/static" (or "/public"). The `index.html` resource is special because it is used as a "welcome page" if it exists, which means it will be served up as the root resource, i.e. at `http://localhost:8080/` in our example. So create this file:
 
 `src/main/resources/static/index.html`
 [source,html]


### PR DESCRIPTION
This fixes a tiny typo in the "Serving Web Content with Spring MVC" guide.