### PR TITLE
Fix gradle-wrapper.properties - looks like a bad merge?

### DIFF
--- a/complete/gradle/wrapper/gradle-wrapper.properties
+++ b/complete/gradle/wrapper/gradle-wrapper.properties
@@ -1,9 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-<<<<<<< HEAD
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
-=======
 distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
->>>>>>> Upgraded to Spring Boot 2.2
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/initial/gradle/wrapper/gradle-wrapper.properties
+++ b/initial/gradle/wrapper/gradle-wrapper.properties
@@ -1,9 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-<<<<<<< HEAD
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
-=======
 distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
->>>>>>> Upgraded to Spring Boot 2.2
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Seems git merge markers made their way into these files, which could then confuse some Gradle installations.